### PR TITLE
Config authorship

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Hongyu1231 <e1484122@u.nus.edu> unknown <185772174+Hongyu1231@users.noreply.github.com>


### PR DESCRIPTION
## Description
This PR resolves a Git authorship issue where my previous commits were mistakenly attributed to an unconfigured author。

This update is crucial to ensure that **RepoSense** can correctly parse the Git history and accurately track my code contributions for grading.

## Changes Made
- Added a `.mailmap` file to the root directory.
- Mapped the incorrect author identity to my github user name and NUS email (`Hongyu1231 <e1484122@u.nus.edu>`).

## Testing
- Verified locally using `git log` and `git blame` that past unconfigured commits now correctly display `Hongyu1231<e1484122@u.nus.edu>`.