### PR TITLE
Implement Semester Change UX Warning and Module Persistence

### DIFF
--- a/src/main/java/seedu/equipmentmaster/commands/SetSemCommand.java
+++ b/src/main/java/seedu/equipmentmaster/commands/SetSemCommand.java
@@ -59,14 +59,19 @@ public class SetSemCommand extends Command {
                 throw new EquipmentMasterException(
                         "Please specify a semester. Usage: setsem AY[YYYY]/[YY] Sem[1/2]");
             }
+
+            // Capture old semester before updating
+            AcademicSemester oldSem = context.getCurrentSemester();
+
             AcademicSemester newSem = new AcademicSemester(rawSem);
             context.setCurrentSemester(newSem);
             storage.saveSettings(newSem);
             ui.showMessage("System time updated. Current academic semester is now set to " + newSem);
 
-            // Warn user to update module enrollments if any modules exist
+            // Only warn if semester actually changed and modules exist
             ModuleList moduleList = context.getModuleList();
-            if (moduleList != null && !moduleList.getModules().isEmpty()) {
+            if (moduleList != null && !moduleList.getModules().isEmpty()
+                    && (oldSem == null || !newSem.equals(oldSem))) {
                 ui.showMessage("[!] WARNING: Semester changed. Please remember to update the enrollment"
                         + " numbers for the following modules using the 'updatemod' command:");
                 for (Module m : moduleList.getModules()) {

--- a/src/test/java/seedu/equipmentmaster/commands/SetSemCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/SetSemCommandTest.java
@@ -1,0 +1,131 @@
+package seedu.equipmentmaster.commands;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.equipmentmaster.context.Context;
+import seedu.equipmentmaster.equipmentlist.EquipmentList;
+import seedu.equipmentmaster.exception.EquipmentMasterException;
+import seedu.equipmentmaster.module.Module;
+import seedu.equipmentmaster.modulelist.ModuleList;
+import seedu.equipmentmaster.semester.AcademicSemester;
+import seedu.equipmentmaster.storage.Storage;
+import seedu.equipmentmaster.ui.Ui;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class SetSemCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    private EquipmentList equipments;
+    private ModuleList moduleList;
+    private Storage storage;
+
+    @BeforeEach
+    public void setUp() {
+        equipments = new EquipmentList();
+        moduleList = new ModuleList();
+        storage = new Storage(
+                tempDir.resolve("test_equipment.txt").toString(),
+                new Ui(),
+                tempDir.resolve("test_settings.txt").toString(),
+                tempDir.resolve("test_modules.txt").toString()
+        );
+    }
+
+    @Test
+    public void execute_emptyModuleList_noWarningShown() throws EquipmentMasterException {
+        // Arrange: no modules, semester changes
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Ui ui = new Ui(System.in, new PrintStream(outputStream));
+        Context context = new Context(equipments, moduleList, ui, storage, null);
+
+        // Act
+        SetSemCommand command = new SetSemCommand("AY2025/26 Sem1");
+        command.execute(context);
+
+        // Assert: warning should NOT appear
+        String output = outputStream.toString();
+        assertFalse(output.contains("[!] WARNING"));
+    }
+
+    @Test
+    public void execute_nonEmptyModuleList_warningShown() throws EquipmentMasterException {
+        // Arrange: modules exist, semester changes
+        moduleList.addModule(new Module("CG2111A", 150));
+        moduleList.addModule(new Module("EE2026", 200));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Ui ui = new Ui(System.in, new PrintStream(outputStream));
+        Context context = new Context(equipments, moduleList, ui, storage, null);
+
+        // Act
+        SetSemCommand command = new SetSemCommand("AY2025/26 Sem1");
+        command.execute(context);
+
+        // Assert: warning should appear with module names
+        String output = outputStream.toString();
+        assertTrue(output.contains("[!] WARNING"));
+        assertTrue(output.contains("CG2111A"));
+        assertTrue(output.contains("EE2026"));
+    }
+
+    @Test
+    public void execute_sameSemester_noWarningShown() throws EquipmentMasterException {
+        // Arrange: modules exist, but semester does NOT change
+        moduleList.addModule(new Module("CG2111A", 150));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Ui ui = new Ui(System.in, new PrintStream(outputStream));
+        AcademicSemester currentSem = new AcademicSemester("AY2025/26 Sem1");
+        Context context = new Context(equipments, moduleList, ui, storage, currentSem);
+
+        // Act: set the same semester
+        SetSemCommand command = new SetSemCommand("AY2025/26 Sem1");
+        command.execute(context);
+
+        // Assert: warning should NOT appear since semester didn't change
+        String output = outputStream.toString();
+        assertFalse(output.contains("[!] WARNING"));
+    }
+
+    @Test
+    public void execute_differentSemester_warningShown() throws EquipmentMasterException {
+        // Arrange: modules exist, semester changes to a different one
+        moduleList.addModule(new Module("CG2111A", 150));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Ui ui = new Ui(System.in, new PrintStream(outputStream));
+        AcademicSemester currentSem = new AcademicSemester("AY2025/26 Sem1");
+        Context context = new Context(equipments, moduleList, ui, storage, currentSem);
+
+        // Act: set a different semester
+        SetSemCommand command = new SetSemCommand("AY2025/26 Sem2");
+        command.execute(context);
+
+        // Assert: warning should appear
+        String output = outputStream.toString();
+        assertTrue(output.contains("[!] WARNING"));
+        assertTrue(output.contains("CG2111A"));
+    }
+
+    @Test
+    public void parse_missingSemester_throwsException() {
+        assertThrows(EquipmentMasterException.class, () -> SetSemCommand.parse("setsem"));
+    }
+
+    @Test
+    public void parse_validSemester_returnsSetSemCommand() throws EquipmentMasterException {
+        Command command = SetSemCommand.parse("setsem AY2025/26 Sem1");
+        assertTrue(command instanceof SetSemCommand);
+    }
+}


### PR DESCRIPTION
## Description
Updated SetSemCommand to warn users to update module enrollments when the semester changes.

## Changes
- `SetSemCommand.java`: After successfully updating the semester, scans the ModuleList and prints a warning listing all active modules and their current enrollment numbers if any exist. If ModuleList is empty, the warning is skipped entirely.

## Edge Cases Handled
- Empty ModuleList: Warning is skipped if no modules are in the system
- Corrupted modules.txt: Already handled by Storage.java — corrupted lines are silently skipped and valid modules still load correctly

## Testing
- All unit tests passing via `./gradlew clean check`
- Text UI test passing via `runtest.bat`
- Manually smoke tested:
  - setsem with no modules — no warning shown
  - setsem with active modules — warning lists all modules with current pax
  - Corrupted modules.txt — app starts normally, corrupted line skipped
 
## Linked Issue
Closes #36 