### PR TITLE
docs: center images and fix heading indentation bugs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -152,9 +152,14 @@ This modular structure ensures that parsing logic is isolated from execution log
 The following diagram illustrates the high-level architecture of the Equipment Master application.
 The `EquipmentMaster` class acts as the main entry point. Upon initialization, it utilizes the `Storage` component to load existing data (equipment, modules, and system settings) into memory (`EquipmentList` and `ModuleList`). During execution, it bundles these instantiated components into a single `Context` object.
 The application then enters a continuous loop: the `Ui` reads user input, the `Parser` translates this string into a specific executable `Command`, and the `Command` executes its logic by interacting with the shared `Context`.
-![Equipment Master Diagram](images/EquipmentMaster.png)
 
+<div align="center">
+
+![Equipment Master Diagram](images/EquipmentMaster.png)
+  
 *Figure 1: High-level architecture diagram illustrating the core components and their interactions.*
+
+</div>
 
 ---
 
@@ -168,9 +173,13 @@ This design choice ensures:
 #### Object Snapshot: The Internal State
 To better understand how data is structured in memory during runtime, the following object diagram provides a snapshot of the `Context` object. It shows how `Equipment` items are logically linked to `Module` codes through string-based tagging.
 
+<div align="center">
+
 ![Object Snapshot Diagram](images/ObjectSnapshot.png)
 
 *Figure 2: Object diagram snapshot of the Context pattern, showing in-memory data references.*
+
+</div>
 
 ---
 
@@ -233,9 +242,13 @@ static {
 
 #### 3. UML Class Diagram
 **Class Diagram: Parser Component**
+<div align="center">
+
 ![Parser Class Diagram](images/parser.png)
 
 *Figure 3: Class diagram of the Parser component utilizing the Command Factory pattern.*
+
+</div>
 
 #### 4. Design Considerations
 * **Command Factory Pattern & Registration**
@@ -264,15 +277,25 @@ The `AddCommand` is instantiated via its static `parse` method. The execution fl
 #### 3. UML Diagrams
 **Class Diagram: AddCommand**
 (Note: This diagram focuses strictly on the internal structure of `AddCommand` and its inheritance from `Command`. Associated domain classes like `Context`, `Equipment`, and `AcademicSemester` are shown as data types, but their full class definitions are omitted here for clarity.)
+
+<div align="center">
+
 ![AddCommand Class Diagram](images/AddCommandClass.png)
 
 *Figure 4: Class diagram detailing the internal structure of the AddCommand.*
 
+</div>
+
 **Sequence Diagram: Execution Flow**
 (Note: This diagram illustrates the `execute()` phase of the command. The initial string parsing and validation steps are handled prior to execution and are omitted for brevity. Storage file I/O operations are shown at a high level.)
+
+<div align="center">
+
 ![AddCommand Sequence Diagram](images/AddCommand.png)
 
 *Figure 5: Sequence diagram showing the execution flow of the Core Inventory Ingestion process.*
+
+</div>
 
 #### 4. Design Considerations
 
@@ -300,9 +323,13 @@ When an equipment item is deleted (e.g., `delete n/STM32 q/5 s/AVAILABLE`), the 
 
 If an equipment is completely removed from the inventory, the system must perform a reverse-cleanup: it automatically triggers an `untag` operation across all modules to ensure no module still expects a requirement ratio from a non-existent item.
 
+<div align="center">
+
 ![Delete Equipment Sequence Diagram](images/DeleteCommand.png)
 
 *Figure 6: Sequence diagram of the Delete feature, highlighting the synchronous reverse-cleanup mechanism.*
+
+</div>
 
 #### 3. Design Considerations
 * **Alternative 1 (Current): Hard Delete with Synchronous Cleanup**
@@ -327,9 +354,13 @@ Each entity is stored in a dedicated `.txt` file using the **Pipe-Delimited Form
 
 #### 2. Loading Logic (The "Robust Loader")
 
+<div align="center">
+
 ![Storage Loading Sequence Diagram](images/StorageLoadingSequence.png)
 
 *Figure 7: Sequence diagram demonstrating the "Silent Recovery" mechanism during Storage loading.*
+
+</div>
 
 During the initialization phase, the `Storage` class reads files line-by-line. To ensure system stability, it employs a **Silent Recovery** mechanism:
 1.  It attempts to parse a line into a data object.
@@ -381,9 +412,13 @@ setbuffer i/1 b/10
 #### 3. Sequence Diagram
 *(Note: Storage persistence and UI confirmation steps are shown at a high level. The name/index-lookup logic within `EquipmentList` is abstracted for brevity.)*
 
+<div align="center">
+
 ![SetBufferCommand Sequence Diagram](images/SetBufferCommand.png)
 
 *Figure 8: Sequence diagram showing the dual-targeting (name/index) execution flow for SetBufferCommand.*
+
+</div>
 
 #### 4. Design Considerations
 * **Alternative 1 (Current Implementation): Dual Targeting (Name or Index)**
@@ -432,9 +467,13 @@ setstatus 1 q/3 s/available
 #### 3. Sequence Diagram
 *(Note: The index-resolution and name-resolution paths share the same downstream logic once the target `Equipment` is identified. The diagram abstracts the branching lookup into a single `resolveTarget()` call for clarity.)*
 
+<div align="center">
+
 ![SetStatusCommand Sequence Diagram](images/SetStatusCommand.png)
 
 *Figure 9: Sequence diagram illustrating the loan/available status update process.*
+
+</div>
 
 #### 4. Design Considerations
 * **Alternative 1 (Current Implementation): Dual Targeting (Name or Index)**
@@ -464,9 +503,13 @@ The execution flow follows these steps:
 #### 3. Sequence Diagram
 The following sequence diagram illustrates the interaction between the `DeleteCommand`, the `Equipment` model, and the `Ui` during a stock breach:
 
+<div align="center">
+
 ![LowStockAlert Sequence Diagram](./images/LowStockAlert.png)
 
 *Figure 10: Sequence diagram of the Low Stock Alert system triggering a UI warning post-transaction.*
+
+</div>
 
 #### 4. Design Considerations
 **Alternative 1 (Current Implementation): Logic-Driven Alerts**
@@ -517,15 +560,25 @@ To illustrate this feature without cluttering a single diagram, the logic is div
 
 **Activity Diagram: Iteration and Early Return**
 *(This diagram omits UI rendering steps to focus purely on the search algorithm's fast-fail mechanism.)*
+
+<div align="center">
+
 ![FindCommand Activity Diagram](images/find_activity.png)
 
 *Figure 11: Activity diagram showcasing the "Early Return" matching logic in the Find feature.*
 
+</div>
+
 **Sequence Diagram: Execution Flow**
 *(Note: Minor parameter details are omitted as `...` for brevity. The low-level matching logic is abstracted into a `ref` frame.)*
+
+<div align="center">
+
 ![FindCommand Sequence Diagram](images/find.png)
 
 *Figure 12: Sequence diagram detailing the iteration and abstraction levels of the FindCommand.*
+
+</div>
 
 #### 4. Design Considerations
 * **Alternative 1 (Current Implementation): Extracted Helpers & Early Returns**
@@ -597,15 +650,25 @@ To illustrate the data structure and execution flow of the Module Tracking Syste
 
 **Class Diagram: System Architecture**
 *(Note: Minor exception classes and standard Java libraries are omitted. The diagram highlights the inheritance of commands and the normalized separation between the `ModuleList` and `Context`.)*
+
+<div align="center">
+
 ![Module System Class Diagram](images/module_class.png)
 
 *Figure 13: Class diagram of the Module Tracking System architecture.*
 
+</div>
+
 **Sequence Diagram: Update Module Execution Flow**
 *(Note: UI rendering steps and generic self-calls have been abstracted to focus on the core Model interactions during an update operation.)*
+
+<div align="center">
+
 ![UpdateMod Sequence Diagram](images/updatemod.png)
 
 *Figure 14: Sequence diagram for updating academic module metadata (e.g., student pax).*
+
+</div>
 
 #### 4. Design Considerations
 * **Alternative 1 (Current Implementation): Normalized Entity Structure**
@@ -650,14 +713,24 @@ The following sequence diagrams illustrate the execution flow for the `TagComman
 *(Note: The initial parsing of user input is omitted for clarity. Standard operations, such as index bounds-checking within the `EquipmentList` and the internal file writing mechanics of the `Storage` class, are abstracted to a high level.)*
 
 **Tag Command Flow**
+
+<div align="center">
+
 ![Tag Command Sequence Diagrams](images/TagCommand.png)
 
 *Figure 15: Sequence diagram illustrating the Academic Dependency Mapping (Tagging) process.*
 
+</div>
+
 **Untag Command Flow**
+
+<div align="center">
+
 ![Untag Command Sequence Diagrams](images/UntagCommand.png)
 
 *Figure 16: Sequence diagram showing the removal of a requirement ratio link.*
+
+</div>
 
 #### 4. Design Considerations
 
@@ -678,9 +751,13 @@ A critical challenge in the Academic Mapping system is maintaining data integrit
 #### 1. Execution Logic
 When a module is deleted (e.g., `delmod n/CG2111A`), the system ensures that no equipment remains "tagged" to a non-existent entity.
 
+<div align="center">
+
 ![Safe Dereferencing Sequence Diagram](images/SafeDereferencing.png)
 
 *Figure 17: Sequence diagram of the Safe Dereferencing protocol during module deletion.*
+
+</div>
 
 1.  **Identification**: The `DelModCommand` queries the `EquipmentList` for any items containing the module code.
 2.  **Cleanup**: It invokes `equipment.removeTag("CG2111A")` on each match.
@@ -712,9 +789,14 @@ During execution:
 #### 3. UML Diagrams
 **Sequence Diagram: Report Generation**
 *(Note: Pseudocode like `calculate age` is used in place of exact mathematical method calls like `calculateAgeInYears()` to keep the diagram abstracted and focused on object interactions.)*
+
+<div align="center">
+
 ![ReportAging Sequence Diagram](images/reportAging.png)
 
 *Figure 18: Sequence diagram for generating the Aging Equipment Report.*
+
+</div>
 
 #### 4. Design Considerations
 * **Alternative 1 (Current Implementation): Semantic Academic Timekeeping (`AY2024/25 Sem1`)**
@@ -735,9 +817,13 @@ A core challenge in the `Aging Report` and `Procurement Report` is performing ma
 
 #### 1. The Normalization Algorithm
 
+<div align="center">
+
 ![Academic Semester Logic Diagram](images/AcademicSemesterLogic.png)
 
 *Figure 19: Class and logic diagram outlining the Academic Semester normalization algorithm.*
+
+</div>
 
 To compare two semesters or calculate the age of an item, the `AcademicSemester` class converts strings into a **Numeric Offset**.
 
@@ -777,9 +863,14 @@ The calculation follows this strict algorithm for each equipment item:
 
 #### 3. Sequence Diagram: Procurement Report Execution
 _(Note: The `getModuleByName` logic is represented as a self-invocation within the `ReportCommand`, and standard math calculations for demand are abstracted to focus on object interactions.)_
+
+<div align="center">
+
 ![Procurement Report Diagram](images/ProcurementReport.png)
 
 *Figure 20: Sequence diagram showing the object interactions for generating the Procurement Report.*
+
+</div>
 
 #### 4. Design Considerations
 **Alternative 1 (Current Implementation): Total Ownership vs. Demand**
@@ -793,9 +884,13 @@ _(Note: The `getModuleByName` logic is represented as a self-invocation within t
 #### 5. The Calculation Pipeline
 The Procurement Report is the most mathematically intensive feature of Equipment Master. It avoids floating-point errors and ensures realistic procurement values by following a strict rounding-up policy.
 
+<div align="center">
+
 ![Procurement Calculation Activity Diagram](images/ProcurementCalculation.png)
 
 *Figure 21: Activity diagram detailing the mathematical pipeline for the procurement calculation engine.*
+
+</div>
 
 **The Formula:**
 `Recommended = ceil(Sum(Module_Pax * Requirement_Ratio) * (1 + Buffer)) - Total_Owned`
@@ -832,16 +927,23 @@ Similarly, `HelpCommand` utilizes `UiTable` but enables the `hasHeader` flag, al
 #### Rendering Flow (Sequence Diagram)
 The following sequence diagram illustrates how `ListCommand` utilizes `UiTable` to dynamically construct and format the inventory output before passing it to the `Ui` for display.
 
+<div align="center">
+
 ![UiTable Sequence Diagram](images/UiTableSequence.png)
 
 *Figure 22: Sequence diagram illustrating how ListCommand utilizes UiTable for dynamic rendering.*
 
+</div>
 
 #### 3. Class Diagram
+
+<div align="center">
+
 ![UiTable Class Diagram](images/uiTable.png)
 
 *Figure 23: Class diagram of the Dynamic UI Table Generation utility.*
 
+</div>
 
 #### 4. Design Considerations
 **Alternative 1 (Current Implementation): Dynamic Column Width Calculation**
@@ -865,9 +967,13 @@ The `HelpCommand` leverages the `UiTable` utility and the centralized `Parser` r
 
 When executed, it retrieves the static list of `CommandSpec` objects from the `Parser`. It iterates through this registry, extracting the keyword and format string of every registered command, and maps them into `UiTableRow` objects to render a perfectly aligned table.
 
+<div align="center">
+
 ![Help Command Sequence Diagram](images/HelpCommand.png)
 
 *Figure 24: Sequence diagram showing the dynamic generation of the Help menu from the Parser registry.*
+
+</div>
 
 #### 3. Design Considerations
 * **Alternative 1 (Current): Dynamic Table Generation**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -175,18 +175,18 @@ Scans your entire inventory and generates a report of all equipment where the cu
 * **Format:** `report lowstock`
 
 * **Example Output:**
+
 ```text
 !!! CRITICAL LOW STOCK WARNING !!!
-
 +----+--------------------+-------+--------+-------+-----+
 | ID | Equipment Name     | Avail | Loaned | Total | Min |
 +----+--------------------+-------+--------+-------+-----+
 | 2  | Oscilloscope       | 0     | 1      | 1     | 2   |
 | 4  | Basys3 FPGA        | 2     | 5      | 7     | 10  |
 +----+--------------------+-------+--------+-------+-----+
-
 Action Required: Please arrange for immediate equipment recovery or procurement.
 ```
+
 
 #### Setting a Safety Buffer: `setbuffer`
 Sets a percentage safety buffer on specific equipment. This ensures you buy slightly more than the baseline module enrollments to account for potential damage, loss, or unexpected student increases.
@@ -200,7 +200,6 @@ Calculates the exact total number of items needed for the upcoming semester by c
 
 ```text
 Generating Procurement Report for upcoming semester...
-
 +----+--------------------+-------+--------+----------+--------+
 | ID | Equipment Name     | Owned | Buffer | Required | To Buy |
 +----+--------------------+-------+--------+----------+--------+
@@ -209,6 +208,7 @@ Generating Procurement Report for upcoming semester...
 | 3  | Soldering Iron     | 25    | 0.0%   | 30       | 5      |
 +----+--------------------+-------+--------+----------+--------+
 ```
+
 
 *Note: 'Required' is calculated based on module enrollment pax, mapped ratios, and the safety buffer (rounded up).*
 
@@ -261,6 +261,7 @@ Displays your entire equipment inventory in a cleanly aligned, responsive table 
 | 5  | Jumper Wires       | 480   | 20     | 500   | 100 | CG2111A          |
 +----+--------------------+-------+--------+-------+-----+------------------+
 ```
+
 
 #### Viewing the interactive manual: `help`
 Provides a comprehensive, in-application guide to all available commands, their parameters, and usage examples.


### PR DESCRIPTION
#### **What does this PR do?**
This PR further refines the User Guide / Developer Guide layouts. It fixes an indentation issue that caused regular text to be swallowed by code blocks, and applies HTML wrappers to professionally center images and figure captions.

#### **Key Changes:**
1. **Fixed Accidental Code Blocks:** Removed unintended leading spaces/tabs before subheadings (e.g., `#### Setting a Safety Buffer`). This prevents the Markdown parser from mistakenly treating normal text and lists as indented code blocks.
2. **Centered Images and Captions:** Wrapped Markdown image syntax (`![...]`) and their corresponding italicized captions (`*Figure X...*`) in `<div align="center">` tags to properly align them in the center of the page or PDF.
3. **Preserved Markdown Rendering:** Applied the necessary empty lines inside the HTML `<div>` tags to ensure the Markdown parser correctly recognizes and renders the images, rather than outputting raw text.

#### **How to Test:**
1. Pull this branch.
2. Preview the modified `.md` files locally or serve the documentation site.
3. Verify that:
   - The text following the "Example Output" code blocks renders as normal Markdown (headings and bullets), not as a grey scrollable box.
   - The diagrams (e.g., Sequence Diagrams, Object Diagrams) and their captions are perfectly centered on the page.
   - The images actually load and are not displayed as raw `![text](url)` syntax.

#### **Checklist:**
- [x] Documentation previews correctly without rendering artifacts
- [x] Images and captions are properly aligned
- [x] No changes were made to the application logic or test suite in this PR