### PR TITLE
Fix several issues related to Procurement Report

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -845,13 +845,12 @@ The Procurement Report is a computed report that calculates recommended semester
 The feature is integrated into the existing `ReportCommand` class to group all analytical logic in one place. The core logic resides in the `executeProcurementReport(Context)` method.
 
 The calculation follows this strict algorithm for each equipment item:
-1.  **Demand Aggregation**: The system iterates through the `moduleCodes` list associated with the equipment. It retrieves the latest enrollment numbers (pax) from the `ModuleList` and sums them up to determine the `Base Demand`.
+1.  **Demand Aggregation**: The system iterates through the `moduleCodes` list associated with the equipment. It retrieves the latest enrollment numbers (pax) from the `ModuleList`. For each module, it calculates the raw demand by multiplying the pax by the requirement ratio, then applies the **Indivisibility Rule** by rounding up to the nearest whole number using `Math.ceil()`. It sums these per-module values to determine the `Base Demand`.
   *   *Orphaned Tag Handling*: If a module code exists in the equipment's tag list but has been deleted from the `ModuleList`, it is gracefully ignored to prevent `NullPointerException`.
-2.  **Buffer Application**: The `Base Demand` is multiplied by `(1 + bufferPercentage / 100.0)`.
-3.  **Indivisibility Rule**: The result is rounded up to the nearest whole number using `Math.ceil()`. You cannot purchase 0.5 of a board.
-4.  **Gap Analysis**: The system subtracts the *Total Quantity* (owned inventory) from the *Total Required*.
+2.  **Buffer Application & Indivisibility**: The `Base Demand` is multiplied by `(1 + bufferPercentage / 100.0)` and the result is rounded up again using `Math.ceil()` to get the *Total Required*. You cannot purchase 0.5 of a board.
+3.  **Gap Analysis**: The system subtracts the *Total Quantity* (owned inventory) from the *Total Required*.
   *   Note: It uses *Total Quantity* rather than *Available Quantity* because procurement decisions are based on total asset ownership, regardless of whether items are currently loaned out.
-5.  **Output**: If `To Buy > 0`, the item is flagged in the report.
+4.  **Output**: If `To Buy > 0`, the item is flagged in the report.
 
 #### 3. Sequence Diagram: Procurement Report Execution
 _(Note: The `getModuleByName` logic is represented as a self-invocation within the `ReportCommand`, and standard math calculations for demand are abstracted to focus on object interactions.)_
@@ -879,9 +878,9 @@ The Procurement Report is the most mathematically intensive feature of Equipment
 </div>
 
 **The Formula:**
-`Recommended = ceil(Sum(Module_Pax * Requirement_Ratio) * (1 + Buffer)) - Total_Owned`
+`Recommended = ceil(Sum(ceil(Module_Pax * Requirement_Ratio)) * (1 + Buffer)) - Total_Owned`
 
-* **Indivisibility Rule**: The system applies `Math.ceil()` because lab equipment cannot be purchased in fractions.
+* **Indivisibility Rule**: The system applies `Math.ceil()` at both the per-module demand calculation and the final buffer calculation because lab equipment cannot be purchased in fractions, and each module class requires whole units.
 * **Ownership Offset**: It subtracts `Total_Quantity` (Available + Loaned) because procurement represents long-term asset acquisition, not immediate shelf availability.
 
 #### 6. Current Limitations & Future Improvements

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -219,13 +219,13 @@ Generating Procurement Report for upcoming semester...
 *Note: 'Required' is calculated based on module enrollment pax, mapped ratios, and the safety buffer (rounded up).*
 
 **How the Calculation Works:**
-1. **Determine Base Demand:** For each equipment, the system checks all the modules it is currently mapped to. It adds up the student enrollment sizes (pax) of these associated modules.
-2. **Apply Safety Buffer & Indivisibility:** The system applies your configured `bufferPercentage` to the Base Demand. Following the "Indivisibility Rule," the result is mathematically rounded *up* to the nearest whole number to ensure you don't procure a fraction of a piece of equipment. This becomes the **Total Required**.
+1. **Determine Base Demand:** For each equipment, the system checks all the modules it is currently mapped to. For each module, it multiplies the student enrollment size (pax) by the equipment requirement ratio and mathematically rounds *up* to the nearest whole number (the "Indivisibility Rule"). It then sums up these values to find the overall **Base Demand**.
+2. **Apply Safety Buffer & Indivisibility:** The system applies your configured `bufferPercentage` to the **Base Demand** and rounds *up* again to ensure you don't procure a fraction of a piece of equipment. This becomes the **Total Required**.
 3. **Calculate Shortfall:** The system then subtracts your current **total stock quantity** for that item (all units you own, including any that are currently on loan) from the Total Required quantity.
 4. **Generate Output:** If the Total Required exceeds your current total stock, the system flags a shortage. The item is added to the report, displaying the exact shortfall quantity you need to procure.
 
 *Example scenario:* 
-If `STM32` boards are needed for `CG2111A` (150 pax) and `CS2113` (50 pax), the **Base Demand** is 200. With a 10% safety buffer set via `setbuffer`, the buffered demand becomes 220. If your current total stock (regardless of how many units are currently loaned out) is 180 units, the `report procurement` command will alert you to a shortfall (TO BUY) of 40 `STM32` boards.
+If `STM32` boards are needed for `CG2111A` (150 pax, ratio 0.5) and `CS2113` (55 pax, ratio 1.0), the requirement for `CG2111A` is 75, and for `CS2113` is 55. The **Base Demand** is 130. With a 10% safety buffer set via `setbuffer`, the buffered demand becomes 143. If your current total stock (regardless of how many units are currently loaned out) is 100 units, the `report procurement` command will alert you to a shortfall (TO BUY) of 43 `STM32` boards.
 
 * **Format:** `report procurement`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -200,32 +200,34 @@ Sets a percentage safety buffer on specific equipment. This ensures you buy slig
 * **Example:** `setbuffer n/STM32 b/10` (Sets a 10% procurement buffer for STM32 boards)
 
 #### Generating the Procurement Report: `report procurement`
-Calculates the exact total number of items needed for the upcoming semester by cross-referencing your current stock levels against the student enrollment sizes (pax) of all associated modules, including any configured safety buffers. This allows you to proactively justify budget requests for equipment shortfalls.
+Calculates how many new items you need to buy for the next semester. It checks your current stock against the number of students (pax) in modules that use the equipment, plus any safety buffers you set.
 
 * **Example Output:**
 
 ```text
-Generating Procurement Report for upcoming semester...
-+----+--------------------+-------+--------+----------+--------+
-| ID | Equipment Name     | Owned | Buffer | Required | To Buy |
-+----+--------------------+-------+--------+----------+--------+
-| 1  | STM32              | 150   | 10.0%  | 198      | 48     |
-| 2  | Basys3 FPGA        | 40    | 5.0%   | 53       | 13     |
-| 3  | Soldering Iron     | 25    | 0.0%   | 30       | 5      |
-+----+--------------------+-------+--------+----------+--------+
+Procurement Report (Current Sem: AY2024/25 Sem1)
+1. STM32
+   - Base Need: 99 (from CS2113)
+   - Buffer: 0% (+0)
+   - Total Required: 99 | Available: 7 | TO BUY: 92
 ```
-
 
 *Note: 'Required' is calculated based on module enrollment pax, mapped ratios, and the safety buffer (rounded up).*
 
 **How the Calculation Works:**
-1. **Determine Base Demand:** For each equipment, the system checks all the modules it is currently mapped to. For each module, it multiplies the student enrollment size (pax) by the equipment requirement ratio and mathematically rounds *up* to the nearest whole number (the "Indivisibility Rule"). It then sums up these values to find the overall **Base Demand**.
-2. **Apply Safety Buffer & Indivisibility:** The system applies your configured `bufferPercentage` to the **Base Demand** and rounds *up* again to ensure you don't procure a fraction of a piece of equipment. This becomes the **Total Required**.
-3. **Calculate Shortfall:** The system then subtracts your current **total stock quantity** for that item (all units you own, including any that are currently on loan) from the Total Required quantity.
-4. **Generate Output:** If the Total Required exceeds your current total stock, the system flags a shortage. The item is added to the report, displaying the exact shortfall quantity you need to procure.
+1. **Calculate Module Need:** For each module using the equipment, the system multiplies the number of students (pax) by the requirement ratio. We round this up to a whole number (since you can't buy part of an item).
+2. **Find Total Need:** We add up the needs from all modules.
+3. **Add Safety Buffer:** We increase the total need by your set buffer percentage and round up again. This gives the **Required** amount.
+4. **Find Shortfall:** We subtract the total items you already own (including loaned items) from the **Required** amount. If you own fewer than you need, the difference is what you need **To Buy**.
 
-*Example scenario:* 
-If `STM32` boards are needed for `CG2111A` (150 pax, ratio 0.5) and `CS2113` (55 pax, ratio 1.0), the requirement for `CG2111A` is 75, and for `CS2113` is 55. The **Base Demand** is 130. With a 10% safety buffer set via `setbuffer`, the buffered demand becomes 143. If your current total stock (regardless of how many units are currently loaned out) is 100 units, the `report procurement` command will alert you to a shortfall (TO BUY) of 43 `STM32` boards.
+**Simple Step-by-Step Example:**
+Let's figure out how many `STM32` boards to buy.
+* They are used in `CG2111A` (150 students, ratio 0.5) -> Need = 75 boards.
+* They are also used in `CS2113` (55 students, ratio 1.0) -> Need = 55 boards.
+* **Total Need:** 75 + 55 = 130 boards.
+* **Buffer:** You set a 10% safety buffer. So, 130 + 10% = 143 boards **Required**.
+* **Current Stock:** You currently own 100 boards.
+* **To Buy:** 143 (Required) - 100 (Owned) = 43 boards. The report will tell you to buy 43 `STM32` boards.
 
 * **Format:** `report procurement`
 

--- a/src/main/java/seedu/equipmentmaster/commands/ReportCommand.java
+++ b/src/main/java/seedu/equipmentmaster/commands/ReportCommand.java
@@ -215,7 +215,7 @@ public class ReportCommand extends Command {
             int baseDemand = 0;
 
             for (String modCode : relatedModules) {
-                Module module = getModuleByName(moduleList, modCode);
+                Module module = moduleList.getModule(modCode);
                 if (module != null) {
                     //This is not efficient due to the copying of the getER()
                     var requirements = module.getEquipmentRequirements();
@@ -264,15 +264,6 @@ public class ReportCommand extends Command {
         if (!foundProcurementNeeded) {
             ui.showMessage("Great news! No procurement needed based on current module requirements.");
         }
-    }
-
-    private Module getModuleByName(ModuleList moduleList, String name) {
-        for (Module m : moduleList.getModules()) {
-            if (m.getName().equalsIgnoreCase(name)) {
-                return m;
-            }
-        }
-        return null; // Orphaned tag or not found
     }
 }
 

--- a/src/main/java/seedu/equipmentmaster/commands/ReportCommand.java
+++ b/src/main/java/seedu/equipmentmaster/commands/ReportCommand.java
@@ -225,7 +225,7 @@ public class ReportCommand extends Command {
                                 "' but not found in its equipment requirements. " +
                                 "Skipping this module for demand calculation.");
                     } else {
-                        double ratio = module.getEquipmentRequirements().get(eq.getName());
+                        double ratio = requirements.get(eq.getName());
                         baseDemand += (int) Math.ceil(module.getPax() * ratio);
                     }
                 } else {

--- a/src/main/java/seedu/equipmentmaster/commands/ReportCommand.java
+++ b/src/main/java/seedu/equipmentmaster/commands/ReportCommand.java
@@ -30,6 +30,7 @@ public class ReportCommand extends Command {
 
     /**
      * Parses the arguments for the 'report' command.
+     *
      * @param fullCommand The complete input string.
      * @return A ReportCommand object.
      * @throws EquipmentMasterException If arguments are missing.
@@ -67,7 +68,7 @@ public class ReportCommand extends Command {
             executeLowStockReport(equipments, ui);
         } else if (reportType.equalsIgnoreCase("aging")) {
             executeAgingReport(equipments, ui, context);
-        } else if (reportType.equalsIgnoreCase("procurement")){
+        } else if (reportType.equalsIgnoreCase("procurement")) {
             executeProcurementReport(context);
         } else {
             ui.showMessage("Invalid report type. Currently supported: aging, lowstock, procurement.");
@@ -96,6 +97,7 @@ public class ReportCommand extends Command {
     }
 
     //@@author Hongyu1231
+
     /**
      * Executes the aging report generation.
      * Identifies and displays equipment that has reached or exceeded its designated lifespan.
@@ -138,7 +140,7 @@ public class ReportCommand extends Command {
      * @param context The application context.
      * @return The determined AcademicSemester.
      * @throws EquipmentMasterException If the user didn't provide a semester
-     *     and the system semester is not set.
+     *                                  and the system semester is not set.
      */
     private AcademicSemester resolveTargetSemester(Context context)
             throws EquipmentMasterException {
@@ -215,8 +217,20 @@ public class ReportCommand extends Command {
             for (String modCode : relatedModules) {
                 Module module = getModuleByName(moduleList, modCode);
                 if (module != null) {
-                    // TODO add requirement ratio later
-                    baseDemand += module.getPax();
+                    //This is not efficient due to the copying of the getER()
+                    var requirements = module.getEquipmentRequirements();
+                    if (!requirements.containsKey(eq.getName())) {
+                        ui.showMessage("Warning: Equipment '" + eq.getName() +
+                                "' is tagged to module '" + module.getName() +
+                                "' but not found in its equipment requirements. " +
+                                "Skipping this module for demand calculation.");
+                    } else {
+                        double ratio = module.getEquipmentRequirements().get(eq.getName());
+                        baseDemand += (int) Math.ceil(module.getPax() * ratio);
+                    }
+                } else {
+                    ui.showMessage("Warning: Module '" + modCode + "' tagged to equipment '" + eq.getName() +
+                            "' not found in module list. Skipping this module for demand calculation.");
                 }
             }
 

--- a/src/test/java/seedu/equipmentmaster/commands/ReportCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/ReportCommandTest.java
@@ -187,6 +187,7 @@ public class ReportCommandTest {
         ModuleList moduleList = new ModuleList();
         moduleList.addModule(new Module("CG2111A", 30));
         moduleList.addModule(new Module("EE2026", 0)); // No demand from this one
+        moduleList.getModule("CG2111A").addEquipmentRequirement("STM32", 1.0);
 
         ArrayList<String> modules = new ArrayList<>(List.of("CG2111A"));
         // Name, Qty, Avail, Loaned, Sem, Life, Modules, Min, Buffer


### PR DESCRIPTION
This pull request updates the procurement report logic and its documentation to more accurately reflect how equipment needs are calculated, especially regarding indivisibility and per-module requirements. The main changes clarify that demand is rounded up at both the per-module and total-buffer stages, and the code now warns users about inconsistent equipment-module mappings. The user and developer guides have been revised for clarity and accuracy, and a test has been updated to include equipment requirements.

**Procurement calculation logic and documentation:**

* Updated the procurement report algorithm in `docs/DeveloperGuide.md` to clarify that demand is rounded up per module (using `Math.ceil()`), then summed, then buffer is applied and rounded up again; also updated the formula and explanation of the indivisibility rule. [[1]](diffhunk://#diff-1a95edf069a4136e9cb71bee758b0dc86996f6051f0d438ec2c424557de7160bL848-R853) [[2]](diffhunk://#diff-1a95edf069a4136e9cb71bee758b0dc86996f6051f0d438ec2c424557de7160bL882-R883)
* Revised the user guide in `docs/UserGuide.md` to simplify and clarify the explanation of how procurement needs are calculated, with a step-by-step example and updated sample output.

**Code improvements for procurement calculation:**

* Modified `executeProcurementReport` in `ReportCommand.java` to use the requirement ratio per module, round up each module's demand, and warn users if equipment-module mappings are inconsistent or missing.
* Added equipment requirement setup in the procurement report test to ensure accurate calculations in `ReportCommandTest.java`.

**Minor documentation and formatting:**

* Added and adjusted minor JavaDoc formatting and spacing in `ReportCommand.java`. [[1]](diffhunk://#diff-810c01bc76defd0c31931b78546252405f455b5c241c1a8329eb41b8becd07c1R33) [[2]](diffhunk://#diff-810c01bc76defd0c31931b78546252405f455b5c241c1a8329eb41b8becd07c1R100)