### PR TITLE
fix: gracefully handle invalid module references in UntagCommand and update sequence diagrams

### DIFF
--- a/docs/UMLs/TagCommand.puml
+++ b/docs/UMLs/TagCommand.puml
@@ -59,55 +59,66 @@ activate Context
 Context --> TagCommand : storage
 deactivate Context
 
+== Existence Validation ==
 TagCommand -> ModuleList : hasModule(moduleName)
 activate ModuleList
-ModuleList --> TagCommand : true
+ModuleList --> TagCommand : moduleExists
 deactivate ModuleList
 
 TagCommand -> EquipmentList : hasEquipment(equipmentName)
 activate EquipmentList
-EquipmentList --> TagCommand : true
+EquipmentList --> TagCommand : equipmentExists
 deactivate EquipmentList
 
-TagCommand -> ModuleList : getModule(moduleName)
-activate ModuleList
-ModuleList --> TagCommand : targetModule
-deactivate ModuleList
+alt !moduleExists && !equipmentExists
+    TagCommand -> TagCommand : throw EquipmentMasterException
+else !moduleExists
+    TagCommand -> TagCommand : throw EquipmentMasterException
+else !equipmentExists
+    TagCommand -> TagCommand : throw EquipmentMasterException
+else Both Exist (Happy Path)
 
-TagCommand -> EquipmentList : findByName(equipmentName)
-activate EquipmentList
-EquipmentList --> TagCommand : targetEquipment
-deactivate EquipmentList
+    TagCommand -> ModuleList : getModule(moduleName)
+    activate ModuleList
+    ModuleList --> TagCommand : targetModule
+    deactivate ModuleList
 
-TagCommand -> Module : addEquipmentRequirement(name, ratio)
-activate Module
-Module --> TagCommand
-deactivate Module
+    TagCommand -> EquipmentList : findByName(equipmentName)
+    activate EquipmentList
+    EquipmentList --> TagCommand : targetEquipment
+    deactivate EquipmentList
 
-TagCommand -> Equipment : addModuleCode(moduleName)
-activate Equipment
-Equipment --> TagCommand
-deactivate Equipment
+    TagCommand -> Module : addEquipmentRequirement(name, ratio)
+    activate Module
+    Module --> TagCommand
+    deactivate Module
 
-TagCommand -> Ui : showMessage(successMessage)
-activate Ui
-Ui --> TagCommand
-deactivate Ui
+    TagCommand -> Equipment : addModuleCode(moduleName)
+    activate Equipment
+    Equipment --> TagCommand
+    deactivate Equipment
 
-TagCommand -> Storage : saveModules(modules)
-activate Storage
-Storage --> TagCommand
-deactivate Storage
+    TagCommand -> Ui : showMessage(successMessage)
+    activate Ui
+    Ui --> TagCommand
+    deactivate Ui
 
-TagCommand -> Storage : saveEquipments(equipments)
-activate Storage
-Storage --> TagCommand
-deactivate Storage
+    TagCommand -> Storage : saveModules(modules)
+    activate Storage
+    Storage --> TagCommand
+    deactivate Storage
+
+    TagCommand -> Storage : saveEquipments(equipments)
+    activate Storage
+    Storage --> TagCommand
+    deactivate Storage
+
+end
 
 TagCommand --> Logic
 deactivate TagCommand
 
-Logic --> User : display success
+Logic --> User : display success or error
 deactivate Logic
 
 @enduml

--- a/docs/UMLs/TagCommand.puml
+++ b/docs/UMLs/TagCommand.puml
@@ -93,7 +93,7 @@ else Both Exist (Happy Path)
     Module --> TagCommand
     deactivate Module
 
-    TagCommand -> Equipment : addModuleCode(moduleName)
+    TagCommand -> Equipment : addModuleCode(targetModule.getName())
     activate Equipment
     Equipment --> TagCommand
     deactivate Equipment

--- a/docs/UMLs/UntagCommand.puml
+++ b/docs/UMLs/UntagCommand.puml
@@ -106,7 +106,7 @@ else equipmentExists == true
         Module --> UntagCommand : isRemovedFromModule
         deactivate Module
 
-        UntagCommand -> Equipment : removeModuleCode(moduleName)
+        UntagCommand -> Equipment : removeModuleCode(officialModuleName)
         activate Equipment
         Equipment --> UntagCommand
         deactivate Equipment
@@ -116,19 +116,18 @@ else equipmentExists == true
             activate Ui
             Ui --> UntagCommand
             deactivate Ui
+
+            UntagCommand -> Storage : saveModules(modules)
+            activate Storage
+            Storage --> UntagCommand
+            deactivate Storage
+            UntagCommand -> Storage : saveEquipments(equipments)
+            activate Storage
+            Storage --> UntagCommand
+            deactivate Storage
         else isRemovedFromModule == false
             UntagCommand -> UntagCommand : throw EquipmentMasterException
         end
-
-        UntagCommand -> Storage : saveModules(modules)
-        activate Storage
-        Storage --> UntagCommand
-        deactivate Storage
-
-        UntagCommand -> Storage : saveEquipments(equipments)
-        activate Storage
-        Storage --> UntagCommand
-        deactivate Storage
     end
 end
 

--- a/docs/UMLs/UntagCommand.puml
+++ b/docs/UMLs/UntagCommand.puml
@@ -59,61 +59,83 @@ activate Context
 Context --> UntagCommand : storage
 deactivate Context
 
+== Existence Validation ==
 UntagCommand -> ModuleList : hasModule(moduleName)
 activate ModuleList
-ModuleList --> UntagCommand : true
+ModuleList --> UntagCommand : moduleExists
 deactivate ModuleList
 
 UntagCommand -> EquipmentList : hasEquipment(equipmentName)
 activate EquipmentList
-EquipmentList --> UntagCommand : true
+EquipmentList --> UntagCommand : equipmentExists
 deactivate EquipmentList
 
-UntagCommand -> ModuleList : getModule(moduleName)
-activate ModuleList
-ModuleList --> UntagCommand : targetModule
-deactivate ModuleList
-
-UntagCommand -> EquipmentList : findByName(equipmentName)
-activate EquipmentList
-EquipmentList --> UntagCommand : targetEquipment
-deactivate EquipmentList
-
-== Bidirectional Removal ==
-UntagCommand -> Module : removeEquipmentRequirement(name)
-activate Module
-Module --> UntagCommand : isRemovedFromModule
-deactivate Module
-
-UntagCommand -> Equipment : removeModuleCode(name)
-activate Equipment
-Equipment --> UntagCommand
-deactivate Equipment
-
-== Conditional Saving ==
-alt isRemovedFromModule == true
-    UntagCommand -> Ui : showMessage("Successfully untagged...")
-    activate Ui
-    Ui --> UntagCommand
-    deactivate Ui
-
-    UntagCommand -> Storage : saveModules(modules)
-    activate Storage
-    Storage --> UntagCommand
-    deactivate Storage
-
-    UntagCommand -> Storage : saveEquipments(equipments)
-    activate Storage
-    Storage --> UntagCommand
-    deactivate Storage
-else isRemovedFromModule == false
+alt !equipmentExists
     UntagCommand -> UntagCommand : throw EquipmentMasterException
+else equipmentExists == true
+
+    UntagCommand -> EquipmentList : findByName(equipmentName)
+    activate EquipmentList
+    EquipmentList --> UntagCommand : targetEquipment
+    deactivate EquipmentList
+
+    alt !moduleExists (Ghost Cleanup Path)
+        UntagCommand -> Equipment : removeModuleCode(moduleName)
+        activate Equipment
+        Equipment --> UntagCommand
+        deactivate Equipment
+
+        UntagCommand -> Ui : showMessage("Notice: cleaned up invalid links...")
+        activate Ui
+        Ui --> UntagCommand
+        deactivate Ui
+
+        UntagCommand -> Storage : saveEquipments(equipments)
+        activate Storage
+        Storage --> UntagCommand
+        deactivate Storage
+
+    else moduleExists == true (Normal Bidirectional Removal)
+        UntagCommand -> ModuleList : getModule(moduleName)
+        activate ModuleList
+        ModuleList --> UntagCommand : targetModule
+        deactivate ModuleList
+
+        UntagCommand -> Module : removeEquipmentRequirement(name)
+        activate Module
+        Module --> UntagCommand : isRemovedFromModule
+        deactivate Module
+
+        UntagCommand -> Equipment : removeModuleCode(moduleName)
+        activate Equipment
+        Equipment --> UntagCommand
+        deactivate Equipment
+
+        alt isRemovedFromModule == true
+            UntagCommand -> Ui : showMessage("Successfully untagged...")
+            activate Ui
+            Ui --> UntagCommand
+            deactivate Ui
+        else isRemovedFromModule == false
+            UntagCommand -> UntagCommand : throw EquipmentMasterException
+        end
+
+        UntagCommand -> Storage : saveModules(modules)
+        activate Storage
+        Storage --> UntagCommand
+        deactivate Storage
+
+        UntagCommand -> Storage : saveEquipments(equipments)
+        activate Storage
+        Storage --> UntagCommand
+        deactivate Storage
+    end
 end
 
 UntagCommand --> Logic
 deactivate UntagCommand
 
-Logic --> User : display result or error
+Logic --> User : display success or error
 deactivate Logic
 
 @enduml

--- a/docs/team/wjw55.md
+++ b/docs/team/wjw55.md
@@ -32,7 +32,7 @@
     -   _Highlights:_ Engineered defensive "Ghost Reference" checks. During `TagCommand#execute` and `UntagCommand#execute`, the system strictly verifies the existence of _both_ the module and the equipment before allowing a link to be created or destroyed, preventing orphaned data and fatal errors during forecasting calculations.
 
 ### Contributions to the User Guide (UG)
--   Authored the **Equipment Inventory Management** section of the User Guide (documenting `add`, `delete`, `setstatus`, and `setmin`).
+-   Authored the **Equipment Inventory Management** section of the User Guide (documenting `add`, `tag`, and `untag`).
 
 -   Structured the documentation to prioritize user readability, providing clear formats and practical daily-use examples. I specifically focused on explaining the mathematical impact of the `req/FRACTION` parameter in the `tag` command so technicians understand how to represent shared lab equipment.
 ### Contributions to the Developer Guide (DG)

--- a/src/main/java/seedu/equipmentmaster/commands/UntagCommand.java
+++ b/src/main/java/seedu/equipmentmaster/commands/UntagCommand.java
@@ -69,14 +69,21 @@ public class UntagCommand extends Command {
         String officialEquipmentName = targetEquipment.getName();
 
         if (!moduleExists) {
-            targetEquipment.removeModuleCode(moduleName);
-            ui.showMessage("Notice: Module '" + moduleName +
-                    "' does not exist in the system, but any invalid links were cleaned up from "
-                    + officialEquipmentName + ".");
-            try {
-                storage.saveEquipments(equipments); // Save the cleaned equipment
-            } catch (EquipmentMasterException e) {
-                ui.showMessage("Warning: Failed to save the data file. " + e.getMessage());
+            boolean hadGhostModuleCode = targetEquipment.hasModuleCode(moduleName);
+            if (hadGhostModuleCode) {
+                targetEquipment.removeModuleCode(moduleName);
+                ui.showMessage("Notice: Module '" + moduleName +
+                        "' does not exist in the system, but invalid links were cleaned up from "
+                        + officialEquipmentName + ".");
+                try {
+                    storage.saveEquipments(equipments); // Save the cleaned equipment
+                } catch (EquipmentMasterException e) {
+                    ui.showMessage("Warning: Failed to save the data file. " + e.getMessage());
+                }
+            } else {
+                ui.showMessage("Notice: Module '" + moduleName +
+                        "' does not exist in the system, and " + officialEquipmentName
+                        + " had no invalid link to clean up.");
             }
             return; // Exit early, since there is no module to update
         }

--- a/src/main/java/seedu/equipmentmaster/commands/UntagCommand.java
+++ b/src/main/java/seedu/equipmentmaster/commands/UntagCommand.java
@@ -57,25 +57,34 @@ public class UntagCommand extends Command {
         boolean moduleExists = modules.hasModule(moduleName);
         boolean equipmentExists = equipments.hasEquipment(equipmentName);
 
-        if (!moduleExists && !equipmentExists) {
-            throw new EquipmentMasterException("Aborted: Neither the module '" + moduleName +
-                    "' nor the equipment '" + equipmentName + "' exists.");
-        } else if (!moduleExists) {
-            throw new EquipmentMasterException("Aborted: Module '" + moduleName + "' does not exist.");
-        } else if (!equipmentExists) {
+        if (!equipmentExists) {
             throw new EquipmentMasterException("Aborted: Equipment '" + equipmentName + "' does not exist.");
         }
 
         // 2. Retrieve the objects
-        Module targetModule = modules.getModule(moduleName);
+
         Equipment targetEquipment = equipments.findByName(equipmentName);
 
         // Grab the official names to ensure a perfect match in the internal lists
         String officialEquipmentName = targetEquipment.getName();
-        String officialModuleName = targetModule.getName();
+
+        if (!moduleExists) {
+            targetEquipment.removeModuleCode(moduleName);
+            ui.showMessage("Notice: Module '" + moduleName +
+                    "' does not exist in the system, but any invalid links were cleaned up from "
+                    + officialEquipmentName + ".");
+            try {
+                storage.saveEquipments(equipments); // Save the cleaned equipment
+            } catch (EquipmentMasterException e) {
+                ui.showMessage("Warning: Failed to save the data file. " + e.getMessage());
+            }
+            return; // Exit early, since there is no module to update
+        }
 
         // 3. Bidirectional Removal (Safe Dereferencing)
         // Remove from Module's requirement map
+        Module targetModule = modules.getModule(moduleName);
+        String officialModuleName = targetModule.getName();
         boolean isRemovedFromModule = targetModule.removeEquipmentRequirement(officialEquipmentName);
 
         // FIX 1: Also remove the module code from the Equipment's internal tag list

--- a/src/test/java/seedu/equipmentmaster/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/UntagCommandTest.java
@@ -83,15 +83,16 @@ class UntagCommandTest {
     // ==========================================
 
     @Test
-    void execute_bothModuleAndEquipmentMissing_throwsException() {
+    void execute_equipmentMissing_throwsException() {
+        // Even if the module is also missing ("GhostMod"), the equipment check fails first
         UntagCommand command = new UntagCommand("GhostMod", "GhostEq");
 
         EquipmentMasterException exception = assertThrows(EquipmentMasterException.class, () -> {
             command.execute(context);
         });
 
-        assertTrue(exception.getMessage().contains
-                ("Neither the module 'GhostMod' nor the equipment 'GhostEq' exists."));
+        // The system now throws the standard missing equipment message
+        assertTrue(exception.getMessage().contains("Aborted: Equipment 'GhostEq' does not exist."));
     }
 
     @Test

--- a/src/test/java/seedu/equipmentmaster/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/UntagCommandTest.java
@@ -143,4 +143,31 @@ class UntagCommandTest {
 
         assertTrue(exception.getMessage().contains("does not currently have stm32 as a requirement"));
     }
+
+    @Test
+    void execute_moduleMissingButEquipmentExists_cleansUpGhostReference() {
+        // 1. Setup Initial State
+        String itemName = "beer";
+        String ghostModName = "GHOST101";
+
+        // Create the equipment and manually inject a ghost module reference
+        Equipment targetEquipment = new Equipment(itemName, 5, 5, 0, null, 0.0, null, 0, 0.0);
+        targetEquipment.addModuleCode(ghostModName);
+        equipmentList.addEquipment(targetEquipment);
+
+        assertFalse(moduleList.hasModule(ghostModName), "Setup error: Ghost module should not exist.");
+
+        // 2. Initialize Command
+        UntagCommand command = new UntagCommand(ghostModName, itemName);
+
+        // 3. Execution & Validation
+        // Assert that executing the command DOES NOT throw an exception
+        assertDoesNotThrow(() -> {
+            command.execute(context);
+        }, "The command should gracefully handle missing modules without throwing an exception.");
+
+        // 4. Verify the ghost reference was successfully scrubbed from the equipment
+        assertFalse(targetEquipment.getModuleCodes().contains(ghostModName),
+                "The ghost module reference was not removed from the equipment.");
+    }
 }


### PR DESCRIPTION
## Overview
This PR addresses edge cases flagged during code review regarding the tagging system and updates our developer documentation to accurately reflect error handling. 

## Code Changes & Bug Fixes
* **Graceful Ghost Cleanup (Fix for #116):** Updated `UntagCommand.execute()` logic. If a user attempts to untag an equipment item from a non-existent module (a "ghost reference" from an older save state), the command no longer aborts. Instead, it gracefully scrubs the invalid reference from the `Equipment` object and saves the corrected state to the hard drive. 

## Documentation Updates
* **TagCommand Sequence Diagram:** Updated the PlantUML diagram to include `alt` blocks that explicitly map out the error paths (throwing `EquipmentMasterException`) when modules or equipment do not exist, ensuring the diagram matches the implementation.
* **UntagCommand Sequence Diagram:** Added a new PlantUML diagram illustrating the bidirectional removal logic, including the new conditional "Ghost Cleanup" path and the dual-saving mechanism.