### PR TITLE
Fix: Prevent silent data loss by enforcing strict batch validation on equipment ingestion

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -199,6 +199,9 @@ The application uses **Java Assertions** to document and verify internal assumpt
 #### 4. Safe Data Persistence
 The `Storage` component is designed to be "Fail-Safe." During the loading phase, if a specific line in the save file is corrupted (e.g., contains an illegal character `|`), the system catches the error, logs a warning, and skips only that specific line. This ensures that a single corrupted record does not prevent the user from accessing the rest of their inventory.
 
+#### 5. Prevention of Silent Data Loss (Batch Conflicts)
+In inventory systems, merging new hardware batches into old ones can destroy depreciation data. The `EquipmentList` enforces strict batch consistency. It intercepts `add` commands that try to merge items with identical names but differing lifespans or purchase semesters, throwing a descriptive exception instead of silently corrupting the laboratory's aging data.
+
 ---
 
 ### Parser Component (Command Factory Pattern)
@@ -265,6 +268,8 @@ The `AddCommand` is instantiated via its static `parse` method. The execution fl
 3.  **Defensive Validation:** The parser strictly rejects names containing reserved storage characters (`|`, `,`, `=`) to prevent save file corruption. Lifespan (`life/`) and purchase semester (`bought/`) are optional flags whose values are only applied when both are provided together; supplying only one of them does not cause a validation error and the partial information is ignored.
 
 4.  **Execution & Save:** Once validated, the `AddCommand` is returned. When executed, it instantiates the `Equipment`, adds it to the `EquipmentList`, and triggers `Storage#save()` to persist the new inventory state.
+
+**5. Strict Batch Validation (Anti-Data Loss):** During insertion into the `EquipmentList`, the system employs a strict batch-matching protocol. If a user attempts to add an item with an existing name but conflicting `purchaseSem` or `lifespanYears`, the `addEquipment` method halts execution and throws an `EquipmentMasterException`. This prevents "silent data loss" where new batch metadata would otherwise overwrite or mix with old inventory records, forcing the user to use unique naming conventions for distinct hardware generations.
 
 #### 3. UML Diagrams
 **Class Diagram: AddCommand**
@@ -1235,6 +1240,9 @@ To test the system with pre-populated data without typing everything manually:
 * **Expected**: Error message: "Quantity must be a valid positive integer." No item is added.
 * **Test Case**: `tag m/NON_EXISTENT n/STM32` (Missing module)
 * **Expected**: Error message: "Module NON_EXISTENT not found in registry."
+
+-   **Test Case**: `add n/Oscilloscope q/5 bought/AY2024/25 Sem2 life/5` (Execute this _after_ an Oscilloscope with `bought/AY2024/25 Sem1` already exists in the system).
+-   **Expected**: The system rejects the addition to protect batch integrity. Error message: "An item named 'Oscilloscope' already exists with a different Purchase Semester or Lifespan! To track this new batch, please give it a unique name..."
 
 #### 11.2 Storage Corruption Recovery
 1. Open `data/equipment.txt` and add a blank line between two items.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -87,6 +87,7 @@ Registers new physical equipment into your laboratory inventory. You can perform
 * **Adding with a low-stock alert threshold:** `add n/Jumper Wires q/500 min/100`
 * **Adding with all parameters:** `add n/Raspberry Pi 4 q/30 m/CG2111A bought/AY2024/25 Sem1 life/4.0 min/5`
 
+**Important Note on Restocking (Batch Tracking):** If you `add` an item with a name that already exists in your inventory, the system will merge the new quantity into your existing stock. However, to protect the accuracy of your Aging Reports, the system enforces **strict batch tracking**. If you try to restock an item but provide a _different_ `bought/` semester or `life/` span than the original, the system will reject the command to prevent old and new hardware from being mixed. To track a brand-new generation of hardware, please give it a unique name (e.g., `add n/Oscilloscope_AY25 ...`).
 
 ### 2. Module Tracking System
 To accurately forecast laboratory demands, the system allows you to register academic modules, track their student enrollment (pax), and dynamically map equipment requirements to them.
@@ -314,6 +315,7 @@ Equipment Master is built with robust validation to prevent accidental data corr
 * Providing negative numbers or text where positive integers are expected (e.g., quantities, pax).
 * Entering reserved characters (`|`, `=`, `,`) in equipment names.
 * Referencing a module or equipment that does not exist in the registry.
+* Attempting to restock an existing equipment item with a `bought/` semester or `life/` span that conflicts with the original batch record.
 
 When an error occurs, the system will reject the invalid input, print a clear error message explaining what went wrong, and safely wait for your next command without crashing.
 
@@ -378,6 +380,11 @@ When an error occurs, the system will reject the invalid input, print a clear er
 **Q: A student is returning equipment but I only remember the item's position in the list, not its full name. Do I need to look up the name first?**
 
 **A:** No, the `setstatus` command supports both name-based and index-based targeting. You can simply use the item's position in the list (e.g., `setstatus 1 q/3 s/available`) to log a return instantly without needing to recall the full equipment name, keeping the process fast during busy peak hours.
+
+
+**Q: I tried to add more stock to an existing item, but I got an error saying the purchase semester or lifespan is different. Why?**
+
+**A:** Equipment Master strictly tracks hardware lifecycles to ensure your Aging Reports are mathematically accurate. To prevent "silent data loss"—where mixing a brand-new batch of hardware with a 5-year-old batch ruins the expiration data for both—the system prevents you from merging items with conflicting lifespans under the exact same name. For the new shipment, please use a distinct name (e.g., `Oscilloscope_Batch2` or `Oscilloscope_AY25`) to track its lifecycle independently.
 
 ---
 

--- a/docs/team/wjw55.md
+++ b/docs/team/wjw55.md
@@ -21,7 +21,7 @@
 
     -   _Justification:_ This forms the foundational database of the entire application. Without a robust way to ingest and structure the physical stock, downstream forecasting and module mapping features would not function.
 
-    -   _Highlights:_ Built a highly flexible parser capable of safely extracting multiple optional and repeating flags without collision.
+    -   _Highlights:_ Built a highly flexible parser capable of safely extracting multiple optional and repeating flags without collision. Engineered Strict Batch Validation. Implemented defensive logic during equipment restocking. If a user attempts to merge new stock into an existing record but provides conflicting batch metadata (different purchase semester or lifespan), the system actively rejects the input to prevent "silent data loss" and protect the mathematical integrity of the Aging Reports.
 
 -   **Academic Dependency Mapping (`tag` and `untag` commands):**
 
@@ -35,8 +35,10 @@
 -   Authored the **Equipment Inventory Management** section of the User Guide (documenting `add`, `tag`, and `untag`).
 
 -   Structured the documentation to prioritize user readability, providing clear formats and practical daily-use examples. I specifically focused on explaining the mathematical impact of the `req/FRACTION` parameter in the `tag` command so technicians understand how to represent shared lab equipment.
+
+-   Authored specific FAQ entries and Error Handling documentation detailing the strict batch tracking rules, ensuring users understand why the system rejects conflicting equipment lifespans during restocking.
 ### Contributions to the Developer Guide (DG)
--   **Authored Feature Implementation Sections:** Detailed the architecture, execution flow, and design considerations for the **Core Inventory Ingestion** (`AddCommand`) and the **Academic Dependency Mapping System** (`TagCommand` & `UntagCommand`), with a strong focus on defensive programming mechanisms like the Double Ghost Reference Check.
+-   **Authored Feature Implementation Sections:** Detailed the architecture, execution flow, and design considerations for the **Core Inventory Ingestion** (`AddCommand`) and the **Academic Dependency Mapping System** (`TagCommand` & `UntagCommand`). Strongly emphasized defensive programming mechanisms, specifically documenting the Double Ghost Reference Check and the Anti-Data Loss Batch Validation protocol.
 
 -   **Contributed UML Diagrams:** Authored PlantUML diagrams mapping out my specific architectural contributions, including:
 

--- a/src/main/java/seedu/equipmentmaster/equipmentlist/EquipmentList.java
+++ b/src/main/java/seedu/equipmentmaster/equipmentlist/EquipmentList.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 
 import seedu.equipmentmaster.equipment.Equipment;
+import seedu.equipmentmaster.exception.EquipmentMasterException;
 
 /**
  * Represents a list that stores all equipment objects in the system.
@@ -32,22 +33,38 @@ public class EquipmentList {
      *
      * @param newEquipment Equipment object to be added.
      */
-    public void addEquipment(Equipment newEquipment) {
+    public void addEquipment(Equipment newEquipment) throws EquipmentMasterException {
         for (Equipment existingItem : equipments) {
-            boolean isNameMatch = existingItem.getName().equalsIgnoreCase(newEquipment.getName());
-            boolean isLifespanMatch = Objects.equals(existingItem.getLifespanYears(), newEquipment.getLifespanYears());
-            boolean isPurchaseSemMatch = Objects.equals(existingItem.getPurchaseSem(), newEquipment.getPurchaseSem());
-            if (isNameMatch && isLifespanMatch && isPurchaseSemMatch) {
-                existingItem.setQuantity(existingItem.getQuantity() + newEquipment.getQuantity());
-                existingItem.setAvailable(existingItem.getAvailable() + newEquipment.getAvailable());
-                existingItem.setLoaned(existingItem.getLoaned() + newEquipment.getLoaned());
 
-                for (String moduleCode : newEquipment.getModuleCodes()) {
-                    existingItem.addModuleCode(moduleCode);
+            // 1. Check if the name matches
+            if (existingItem.getName().equalsIgnoreCase(newEquipment.getName())) {
+
+                // 2. Check if the batch details match
+                boolean isLifespanMatch = Objects.equals(existingItem.getLifespanYears(),
+                        newEquipment.getLifespanYears());
+                boolean isPurchaseSemMatch = Objects.equals(existingItem.getPurchaseSem(),
+                        newEquipment.getPurchaseSem());
+
+                if (isLifespanMatch && isPurchaseSemMatch) {
+                    // EXACT MATCH: It is safe to merge the quantities.
+                    existingItem.setQuantity(existingItem.getQuantity() + newEquipment.getQuantity());
+                    existingItem.setAvailable(existingItem.getAvailable() + newEquipment.getAvailable());
+                    existingItem.setLoaned(existingItem.getLoaned() + newEquipment.getLoaned());
+
+                    for (String moduleCode : newEquipment.getModuleCodes()) {
+                        existingItem.addModuleCode(moduleCode);
+                    }
+                    return; // Exit early, we are done updating
+                } else {
+                    // CONFLICT: Name is the same, but it's a different batch. Reject it!
+                    throw new EquipmentMasterException("An item named '" + newEquipment.getName() +
+                            "' already exists with a different Purchase Semester or Lifespan! " +
+                            "To track this new batch, please give it a unique name (e.g., " +
+                            newEquipment.getName() + "_New).");
                 }
-                return;
             }
         }
+        // If the loop finishes, the name is completely unique. Add it.
         equipments.add(newEquipment);
     }
 

--- a/src/main/java/seedu/equipmentmaster/equipmentlist/EquipmentList.java
+++ b/src/main/java/seedu/equipmentmaster/equipmentlist/EquipmentList.java
@@ -49,8 +49,10 @@ public class EquipmentList {
                 }
 
                 // 2. Check if the batch details match exactly
-                boolean isLifespanMatch = Objects.equals(existingItem.getLifespanYears(), newEquipment.getLifespanYears());
-                boolean isPurchaseSemMatch = Objects.equals(existingItem.getPurchaseSem(), newEquipment.getPurchaseSem());
+                boolean isLifespanMatch = Objects.equals(existingItem.getLifespanYears(),
+                        newEquipment.getLifespanYears());
+                boolean isPurchaseSemMatch = Objects.equals(existingItem.getPurchaseSem(),
+                        newEquipment.getPurchaseSem());
 
                 if (isLifespanMatch && isPurchaseSemMatch) {
                     // EXACT MATCH FOUND: It is safe to merge the quantities.

--- a/src/main/java/seedu/equipmentmaster/equipmentlist/EquipmentList.java
+++ b/src/main/java/seedu/equipmentmaster/equipmentlist/EquipmentList.java
@@ -34,19 +34,26 @@ public class EquipmentList {
      * @param newEquipment Equipment object to be added.
      */
     public void addEquipment(Equipment newEquipment) throws EquipmentMasterException {
+        boolean hasNameMatch = false;
+        Equipment conflictingItem = null; // Store for the error message
+
         for (Equipment existingItem : equipments) {
 
             // 1. Check if the name matches
             if (existingItem.getName().equalsIgnoreCase(newEquipment.getName())) {
+                hasNameMatch = true;
 
-                // 2. Check if the batch details match
-                boolean isLifespanMatch = Objects.equals(existingItem.getLifespanYears(),
-                        newEquipment.getLifespanYears());
-                boolean isPurchaseSemMatch = Objects.equals(existingItem.getPurchaseSem(),
-                        newEquipment.getPurchaseSem());
+                // Save the first conflicting item we see so we can use its stats in the error message later
+                if (conflictingItem == null) {
+                    conflictingItem = existingItem;
+                }
+
+                // 2. Check if the batch details match exactly
+                boolean isLifespanMatch = Objects.equals(existingItem.getLifespanYears(), newEquipment.getLifespanYears());
+                boolean isPurchaseSemMatch = Objects.equals(existingItem.getPurchaseSem(), newEquipment.getPurchaseSem());
 
                 if (isLifespanMatch && isPurchaseSemMatch) {
-                    // EXACT MATCH: It is safe to merge the quantities.
+                    // EXACT MATCH FOUND: It is safe to merge the quantities.
                     existingItem.setQuantity(existingItem.getQuantity() + newEquipment.getQuantity());
                     existingItem.setAvailable(existingItem.getAvailable() + newEquipment.getAvailable());
                     existingItem.setLoaned(existingItem.getLoaned() + newEquipment.getLoaned());
@@ -54,17 +61,25 @@ public class EquipmentList {
                     for (String moduleCode : newEquipment.getModuleCodes()) {
                         existingItem.addModuleCode(moduleCode);
                     }
-                    return; // Exit early, we are done updating
-                } else {
-                    // CONFLICT: Name is the same, but it's a different batch. Reject it!
-                    throw new EquipmentMasterException("An item named '" + newEquipment.getName() +
-                            "' already exists with a different Purchase Semester or Lifespan! " +
-                            "To track this new batch, please give it a unique name (e.g., " +
-                            newEquipment.getName() + "_New).");
+                    return; // Exit early, we successfully merged!
                 }
             }
         }
-        // If the loop finishes, the name is completely unique. Add it.
+
+        // 3. Post-Loop Check
+        if (hasNameMatch && conflictingItem != null) {
+            // We searched the whole list. The name exists, but the batch details didn't match any of them.
+            throw new EquipmentMasterException("An item named '" + newEquipment.getName()
+                    + "' already exists with different batch details. Existing values: "
+                    + "bought/" + conflictingItem.getPurchaseSem() + ", life/"
+                    + conflictingItem.getLifespanYears() + ". Attempted values: bought/"
+                    + newEquipment.getPurchaseSem() + ", life/"
+                    + newEquipment.getLifespanYears() + ". "
+                    + "To track this new batch, please give it a unique name (e.g., "
+                    + newEquipment.getName() + "_New).");
+        }
+
+        // If we reach here, the name is completely unique in the system. Add it.
         equipments.add(newEquipment);
     }
 

--- a/src/test/java/seedu/equipmentmaster/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/DeleteCommandTest.java
@@ -115,7 +115,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_deleteMoreThanAvailable_throwsException() {
+    public void execute_deleteMoreThanAvailable_throwsException() throws EquipmentMasterException {
         // Setup: Total 5, Available 2, Loaned 3
         Equipment eq = new Equipment("Breadboard", 5);
         eq.setAvailable(2);
@@ -135,7 +135,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_deleteMoreThanLoaned_throwsException() {
+    public void execute_deleteMoreThanLoaned_throwsException() throws EquipmentMasterException {
         // Setup: Total 5, Available 4, Loaned 1
         Equipment eq = new Equipment("Raspberry Pi", 5);
         eq.setAvailable(4);
@@ -203,7 +203,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndex_throwsException() {
+    public void execute_invalidIndex_throwsException() throws EquipmentMasterException {
         // Arrange
         EquipmentList equipments = new EquipmentList();
         Ui ui = new Ui();

--- a/src/test/java/seedu/equipmentmaster/commands/FindCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/FindCommandTest.java
@@ -24,7 +24,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_keywordMatches_returnsMatchedList() {
+    public void getMatchingEquipments_keywordMatches_returnsMatchedList() throws EquipmentMasterException {
         // Arrange
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32 Development Board", 50));
@@ -42,7 +42,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_keywordNoMatch_returnsEmptyList() {
+    public void getMatchingEquipments_keywordNoMatch_returnsEmptyList() throws EquipmentMasterException {
         // Arrange
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32 Development Board", 50));
@@ -58,7 +58,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_multipleKeywords_returnsMatchedList() {
+    public void getMatchingEquipments_multipleKeywords_returnsMatchedList() throws EquipmentMasterException {
         // Arrange
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32 Development Board", 50));
@@ -81,7 +81,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_moduleCodeCaseInsensitive_returnsMatchedList() {
+    public void getMatchingEquipments_moduleCodeCaseInsensitive_returnsMatchedList() throws EquipmentMasterException {
         // Arrange
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(createEquipmentWithModules("FPGA", 40, "EE2026"));
@@ -97,7 +97,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_searchByModuleCode_returnsMatchedList() {
+    public void getMatchingEquipments_searchByModuleCode_returnsMatchedList() throws EquipmentMasterException {
         // Arrange
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(createEquipmentWithModules("FPGA", 40, "EE2026", "CG2028"));
@@ -147,7 +147,7 @@ public class FindCommandTest {
      * This uses a local anonymous stub to bypass the standard Equipment constructor normalization.
      */
     @Test
-    public void getMatchingEquipments_nullModuleCodes_handledDefensively() {
+    public void getMatchingEquipments_nullModuleCodes_handledDefensively() throws EquipmentMasterException {
         // 1. ARRANGE
         EquipmentList equipments = new EquipmentList();
 
@@ -185,7 +185,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_noMatchesFound_printsMessage() {
+    public void execute_noMatchesFound_printsMessage() throws EquipmentMasterException {
         // Triggers line 157: "There is no matching equipment in your list."
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("HDMI", 10));
@@ -199,7 +199,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_singleMatch_printsSingularMessage() {
+    public void execute_singleMatch_printsSingularMessage() throws EquipmentMasterException {
         // Triggers line 159 and 166: singular "1 equipment listed!" without index
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32", 10));
@@ -213,7 +213,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleMatches_printsPluralMessage() {
+    public void execute_multipleMatches_printsPluralMessage() throws EquipmentMasterException {
         // Triggers line 161 and 168: plural "X equipments listed!" with indexes (1. ..., 2. ...)
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32 Board", 10));
@@ -244,7 +244,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_extraSpacesInKeyword_triggersContinue() {
+    public void getMatchingEquipments_extraSpacesInKeyword_triggersContinue() throws EquipmentMasterException {
         // Multiple spaces result in empty strings in the tokens array, triggering line 88
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32 Board", 10));
@@ -256,7 +256,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_modulesExistButNoMatch_returnsFalse() {
+    public void getMatchingEquipments_modulesExistButNoMatch_returnsFalse() throws EquipmentMasterException {
         // Item has modules, but keyword matches neither name nor modules, triggering line 124
         EquipmentList equipments = new EquipmentList();
         Equipment eq = new Equipment("Oscilloscope", 5);
@@ -285,7 +285,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_multipleSpaces_coversContinue() {
+    public void getMatchingEquipments_multipleSpaces_coversContinue() throws EquipmentMasterException {
         // While \\s+ usually prevents empty tokens, providing a keyword with
         // unusual spacing helps ensure the 'continue' branch (line 88) is evaluated.
         EquipmentList equipments = new EquipmentList();
@@ -296,7 +296,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void matchesNameOrModule_nullAndEmptyModules_coversLine114() {
+    public void matchesNameOrModule_nullAndEmptyModules_coversLine114() throws EquipmentMasterException {
         EquipmentList equipments = new EquipmentList();
 
         // Case 1: Trigger eq.getModuleCodes() == null
@@ -314,7 +314,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void matchesNameOrModule_noMatchInExistingModules_coversLine124() {
+    public void matchesNameOrModule_noMatchInExistingModules_coversLine124() throws EquipmentMasterException {
         // Covers the red 'return false' at line 124
         EquipmentList equipments = new EquipmentList();
         Equipment eq = new Equipment("Oscilloscope", 5);
@@ -340,7 +340,7 @@ public class FindCommandTest {
      * Since parse() blocks empty inputs, we must invoke the constructor directly.
      */
     @Test
-    public void getMatchingEquipments_emptyKeyword_returnsAllEquipments() {
+    public void getMatchingEquipments_emptyKeyword_returnsAllEquipments() throws EquipmentMasterException {
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("Item A", 10));
         equipments.addEquipment(new Equipment("Item B", 20));
@@ -358,7 +358,7 @@ public class FindCommandTest {
      * In Java, split("\\s+") only produces an empty token if the string STARTS with spaces.
      */
     @Test
-    public void getMatchingEquipments_leadingSpaces_triggersEmptyTokenContinue() {
+    public void getMatchingEquipments_leadingSpaces_triggersEmptyTokenContinue() throws EquipmentMasterException {
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32", 10));
 
@@ -383,7 +383,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void getMatchingEquipments_handlingSpaces_success() {
+    public void getMatchingEquipments_handlingSpaces_success() throws EquipmentMasterException {
         EquipmentList equipments = new EquipmentList();
         equipments.addEquipment(new Equipment("STM32", 10));
 

--- a/src/test/java/seedu/equipmentmaster/commands/ReportCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/ReportCommandTest.java
@@ -325,7 +325,7 @@ public class ReportCommandTest {
      * Targets displayAgingEquipments(): Exercises the catch(EquipmentMasterException) block.
      */
     @Test
-    public void execute_calcAgeException_caught() {
+    public void execute_calcAgeException_caught() throws EquipmentMasterException {
         // We use an anonymous subclass to FORCE calculateAgeInYears to throw an exception
         Equipment faultyEq = new Equipment("FaultyEq", 10) {
             @Override

--- a/src/test/java/seedu/equipmentmaster/commands/SetMinCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/SetMinCommandTest.java
@@ -66,7 +66,7 @@ public class SetMinCommandTest {
     }
 
     @Test
-    public void execute_invalidIndex_throwsException() {
+    public void execute_invalidIndex_throwsException() throws EquipmentMasterException {
         // Arrange
         equipments.addEquipment(new Equipment("Resistor", 10));
 
@@ -76,7 +76,7 @@ public class SetMinCommandTest {
     }
 
     @Test
-    public void execute_nameNotFound_throwsException() {
+    public void execute_nameNotFound_throwsException() throws EquipmentMasterException {
         // Arrange
         equipments.addEquipment(new Equipment("Resistor", 10));
 

--- a/src/test/java/seedu/equipmentmaster/commands/TagCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/TagCommandTest.java
@@ -120,7 +120,7 @@ class TagCommandTest {
     }
 
     @Test
-    void execute_moduleMissing_throwsException() {
+    void execute_moduleMissing_throwsException() throws EquipmentMasterException {
         // Add an equipment to the dummy context, but NO module
         equipmentList.addEquipment(new Equipment("stm32", 50, 50, 0, null, 5.0, new ArrayList<>(), 5, 0.0));
 

--- a/src/test/java/seedu/equipmentmaster/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/equipmentmaster/commands/UntagCommandTest.java
@@ -120,7 +120,7 @@ class UntagCommandTest {
     }
 
     @Test
-    void execute_untagNonExistentRequirement_throwsException() {
+    void execute_untagNonExistentRequirement_throwsException() throws EquipmentMasterException {
         // 1. Setup Context, but DO NOT pre-tag the module
         Module testModule = null;
         try {
@@ -145,7 +145,7 @@ class UntagCommandTest {
     }
 
     @Test
-    void execute_moduleMissingButEquipmentExists_cleansUpGhostReference() {
+    void execute_moduleMissingButEquipmentExists_cleansUpGhostReference() throws EquipmentMasterException {
         // 1. Setup Initial State
         String itemName = "beer";
         String ghostModName = "GHOST101";

--- a/src/test/java/seedu/equipmentmaster/equipmentlist/EquipmentListTest.java
+++ b/src/test/java/seedu/equipmentmaster/equipmentlist/EquipmentListTest.java
@@ -132,7 +132,7 @@ class EquipmentListTest {
     }
 
     @Test
-    public void findByName_and_hasEquipment_caseInsensitive_success() throws Exception {
+    public void findAndHasEquipment_caseInsensitive_success() throws Exception {
         EquipmentList equipmentList = new EquipmentList();
         Equipment eq1 = new Equipment("Raspberry Pi", 10, 10, 0, null, 0.0, new ArrayList<>(), 0, 0.0);
         equipmentList.addEquipment(eq1);

--- a/src/test/java/seedu/equipmentmaster/equipmentlist/EquipmentListTest.java
+++ b/src/test/java/seedu/equipmentmaster/equipmentlist/EquipmentListTest.java
@@ -1,0 +1,173 @@
+package seedu.equipmentmaster.equipmentlist;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.equipmentmaster.equipment.Equipment;
+import seedu.equipmentmaster.exception.EquipmentMasterException;
+import seedu.equipmentmaster.semester.AcademicSemester;
+
+class EquipmentListTest {
+
+    @Test
+    public void addEquipment_exactBatchMatch_mergesQuantities() throws Exception {
+        EquipmentList equipmentList = new EquipmentList();
+        AcademicSemester sem1 = new AcademicSemester("AY2024/25 Sem1");
+
+        // 1. Add the first batch
+        Equipment eq1 = new Equipment("Oscilloscope", 10, 10, 0,
+                sem1, 5.0, new ArrayList<>(), 0, 0.0);
+        equipmentList.addEquipment(eq1);
+
+        // 2. Add an exact matching batch (same name, same sem, same lifespan)
+        Equipment eq2 = new Equipment("Oscilloscope", 5, 5, 0,
+                sem1, 5.0, new ArrayList<>(), 0, 0.0);
+        equipmentList.addEquipment(eq2);
+
+        // 3. Verify it merged successfully (Size is still 1, Quantity is now 15)
+        assertEquals(1, equipmentList.getSize());
+        assertEquals(15, equipmentList.findByName("Oscilloscope").getQuantity());
+        assertEquals(15, equipmentList.findByName("Oscilloscope").getAvailable());
+    }
+
+    @Test
+    public void addEquipment_conflictingBatch_throwsException() throws Exception {
+        EquipmentList equipmentList = new EquipmentList();
+        AcademicSemester sem1 = new AcademicSemester("AY2024/25 Sem1");
+        AcademicSemester sem2 = new AcademicSemester("AY2024/25 Sem2"); // Different Sem
+
+        // 1. Add the first batch
+        Equipment eq1 = new Equipment("Oscilloscope", 10, 10, 0,
+                sem1, 5.0, new ArrayList<>(), 0, 0.0);
+        equipmentList.addEquipment(eq1);
+
+        // 2. Create a conflicting batch (same name, DIFFERENT semester)
+        Equipment conflictingEq = new Equipment("Oscilloscope", 5, 5, 0,
+                sem2, 5.0, new ArrayList<>(), 0, 0.0);
+
+        // 3. Assert that attempting to add it throws the EquipmentMasterException
+        assertThrows(EquipmentMasterException.class, () -> {
+            equipmentList.addEquipment(conflictingEq);
+        });
+
+        // 4. Verify the original item was not corrupted
+        assertEquals(1, equipmentList.getSize());
+        assertEquals(10, equipmentList.findByName("Oscilloscope").getQuantity());
+    }
+
+    @Test
+    public void addEquipment_legacyDuplicateNames_findsCorrectBatchToMerge() throws Exception {
+        EquipmentList equipmentList = new EquipmentList();
+        AcademicSemester sem1 = new AcademicSemester("AY2024/25 Sem1");
+        AcademicSemester sem2 = new AcademicSemester("AY2024/25 Sem2");
+
+        // 1. Simulate legacy data where two batches of "Oscilloscope" already exist
+        Equipment legacyBatch1 = new Equipment("Oscilloscope", 10, 10, 0,
+                sem1, 5.0, new ArrayList<>(), 0, 0.0);
+        Equipment legacyBatch2 = new Equipment("Oscilloscope", 20, 20, 0,
+                sem2, 5.0, new ArrayList<>(), 0, 0.0);
+
+        equipmentList.addEquipment(legacyBatch1);
+        // Temporarily bypass the addEquipment validation to insert the legacy duplicate
+        equipmentList.getAllEquipments().add(legacyBatch2);
+
+        // 2. Add a new batch that matches the SECOND legacy batch
+        Equipment newStock = new Equipment("Oscilloscope", 5, 5, 0,
+                sem2, 5.0, new ArrayList<>(), 0, 0.0);
+
+        equipmentList.addEquipment(newStock);
+
+        // 3. Verify it skipped batch1 and successfully merged into batch2
+        assertEquals(10, equipmentList.getEquipment(0).getQuantity()); // Batch 1 unchanged
+        assertEquals(25, equipmentList.getEquipment(1).getQuantity()); // Batch 2 merged (20 + 5)
+    }
+
+    @Test
+    public void addEquipment_exactBatchMatch_mergesModuleCodes() throws Exception {
+        EquipmentList equipmentList = new EquipmentList();
+        AcademicSemester sem = new AcademicSemester("AY2024/25 Sem1");
+
+        // 1. Add item tagged to CG2111A
+        ArrayList<String> mods1 = new ArrayList<>();
+        mods1.add("CG2111A");
+        Equipment eq1 = new Equipment("STM32", 10, 10, 0, sem, 5.0, mods1, 0, 0.0);
+        equipmentList.addEquipment(eq1);
+
+        // 2. Add identical item but tagged to EE2026
+        ArrayList<String> mods2 = new ArrayList<>();
+        mods2.add("EE2026");
+        Equipment eq2 = new Equipment("STM32", 5, 5, 0, sem, 5.0, mods2, 0, 0.0);
+        equipmentList.addEquipment(eq2);
+
+        // 3. Verify the merged item has BOTH module codes
+        Equipment mergedItem = equipmentList.findByName("STM32");
+        assertEquals(1, equipmentList.getSize());
+        assertTrue(mergedItem.getModuleCodes().contains("CG2111A"));
+        assertTrue(mergedItem.getModuleCodes().contains("EE2026"));
+    }
+
+    @Test
+    public void addEquipment_nullBatchDetails_mergesSuccessfully() throws Exception {
+        EquipmentList equipmentList = new EquipmentList();
+
+        // 1. Add basic item (purchaseSem is null, lifespan is 0.0)
+        Equipment eq1 = new Equipment("Resistor", 100, 100, 0, null, 0.0, new ArrayList<>(), 0, 0.0);
+        equipmentList.addEquipment(eq1);
+
+        // 2. Add another basic item
+        Equipment eq2 = new Equipment("Resistor", 50, 50, 0, null, 0.0, new ArrayList<>(), 0, 0.0);
+        equipmentList.addEquipment(eq2);
+
+        // 3. Verify Objects.equals(null, null) worked and merged them
+        assertEquals(1, equipmentList.getSize());
+        assertEquals(150, equipmentList.findByName("Resistor").getQuantity());
+    }
+
+    @Test
+    public void findByName_and_hasEquipment_caseInsensitive_success() throws Exception {
+        EquipmentList equipmentList = new EquipmentList();
+        Equipment eq1 = new Equipment("Raspberry Pi", 10, 10, 0, null, 0.0, new ArrayList<>(), 0, 0.0);
+        equipmentList.addEquipment(eq1);
+
+        // Verify hasEquipment works regardless of case
+        assertTrue(equipmentList.hasEquipment("raspberry pi"));
+        assertTrue(equipmentList.hasEquipment("RASPBERRY PI"));
+        assertFalse(equipmentList.hasEquipment("Arduino"));
+
+        // Verify findByName returns the correct object
+        Equipment foundItem = equipmentList.findByName("rAsPbErRy pI");
+        assertEquals("Raspberry Pi", foundItem.getName());
+
+        // Verify findByName returns null for missing items
+        assertNull(equipmentList.findByName("NonExistentItem"));
+    }
+
+    @Test
+    public void removeEquipment_updatesSizeAndList() throws Exception {
+        EquipmentList equipmentList = new EquipmentList();
+        Equipment eq1 = new Equipment("Oscilloscope", 10, 10, 0, null, 0.0, new ArrayList<>(), 0, 0.0);
+        Equipment eq2 = new Equipment("Multimeter", 5, 5, 0, null, 0.0, new ArrayList<>(), 0, 0.0);
+
+        equipmentList.addEquipment(eq1);
+        equipmentList.addEquipment(eq2);
+        assertEquals(2, equipmentList.getSize());
+
+        // Test remove by object
+        equipmentList.removeEquipment(eq1);
+        assertEquals(1, equipmentList.getSize());
+        assertFalse(equipmentList.hasEquipment("Oscilloscope"));
+
+        // Test remove by index
+        equipmentList.removeEquipment(0);
+        assertEquals(0, equipmentList.getSize());
+        assertTrue(equipmentList.isEmpty());
+    }
+}


### PR DESCRIPTION
**Overview** 
This PR addresses a critical "silent data loss" vulnerability in the core inventory ingestion system (`AddCommand` / `EquipmentList`). It enforces strict batch validation to ensure that newly added equipment does not corrupt the lifecycle data of existing inventory.

**The Problem**
 Previously, if a user added a new batch of equipment that shared a name with existing stock (e.g., `Oscilloscope`), but had a different `purchaseSem` or `lifespanYears`, the system would blindly merge the quantities. This silently overwrote or ignored the new batch's lifecycle metadata, corrupting the database and rendering the **Aging Equipment Report** mathematically inaccurate.

**The Solution**
 Instead of silently merging conflicting batches or completely removing the lifecycle tracking fields, the system now utilizes a "Strict Batch Validation" protocol.

-   The `addEquipment` method checks if the incoming item matches an existing name.
    
-   If the name matches, it strictly compares the `purchaseSem` and `lifespanYears`.
    
-   **Exact Matches:** Merges the quantities safely.
    
-   **Conflicts:** Rejects the input and throws an `EquipmentMasterException` with a descriptive error message advising the user to use a unique naming convention for the new batch (e.g., `Oscilloscope_AY25`).
    

**Changes Made**

-   **Code:** Updated `EquipmentList#addEquipment` to include validation logic and throw `EquipmentMasterException` on batch conflicts.
    
-   **Developer Guide (DG):** * Documented the new validation protocol under `Core Inventory Ingestion`.
    
    -   Highlighted the feature under `Defensive Programming: Prevention of Silent Data Loss`.
        
    -   Added a negative test case for Storage Robustness.
        
-   **User Guide (UG):** * Added a restocking warning to the `add` command section.
    
    -   Updated `Error Handling` and `FAQ` to explain why conflicting batches are rejected.
        
-   **Project Portfolio Page (PPP):** Added this defensive architecture to the project highlights.